### PR TITLE
In the ASP.NET example, removed the empty constructor from DBContexts…

### DIFF
--- a/ExampleAspNetCoreApplication/ExampleAspNetCoreApplication/SecondContext.cs
+++ b/ExampleAspNetCoreApplication/ExampleAspNetCoreApplication/SecondContext.cs
@@ -6,9 +6,4 @@ public class SecondContext : DbContext
 {
     public SecondContext(DbContextOptions<SecondContext> options) : base(options) { }
     public DbSet<SecondForecast> SecondForecasts { get; set; }
-
-    public SecondContext()
-    {
-        // Necessary for unit testing, unfrotunately.
-    }
 }

--- a/ExampleAspNetCoreApplication/ExampleAspNetCoreApplication/WeatherContext.cs
+++ b/ExampleAspNetCoreApplication/ExampleAspNetCoreApplication/WeatherContext.cs
@@ -6,9 +6,4 @@ public class WeatherContext : DbContext
 {
     public WeatherContext(DbContextOptions<WeatherContext> options) : base(options) { }
     public DbSet<WeatherForecast> Forecasts { get; set; }
-
-    public WeatherContext()
-    {
-        // Necessary for unit testing, unfrotunately.
-    }
 }


### PR DESCRIPTION
… since it is no longer necessary.