### PR TITLE
Fixed nuget publish workflow

### DIFF
--- a/.github/workflows/nuget-publish-scenario-unit-testing.yml
+++ b/.github/workflows/nuget-publish-scenario-unit-testing.yml
@@ -22,7 +22,10 @@ jobs:
 
     - name: Extract version from .csproj
       id: extract_version
-      run: echo "##[set-output name=VERSION;]$(dotnet msbuild JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj -nologo -verbosity:quiet -target:GetAssemblyVersion | grep Version | sed 's/.*Version=//')"
+      run: |
+        VERSION=$(grep -oPm1 "(?<=<Version>)[^<]+" JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj)
+        echo "Extracted version: $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Restore dependencies
       run: dotnet restore
@@ -31,7 +34,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Pack the project
-      run: dotnet pack JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj --configuration Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.extract_version.outputs.VERSION }}
+      run: dotnet pack JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj --configuration Release --no-build -o ./artifacts /p:PackageVersion=${{ env.VERSION }}
 
     # - name: Publish to NuGet
     #   env:

--- a/.github/workflows/nuget-publish-scenario-unit-testing.yml
+++ b/.github/workflows/nuget-publish-scenario-unit-testing.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Pack the project
       run: dotnet pack JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj --configuration Release --no-build -o ./artifacts /p:PackageVersion=${{ env.VERSION }}
 
-    # - name: Publish to NuGet
-    #   env:
-    #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-    #   run: dotnet nuget push ./artifacts/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+    - name: Publish to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push ./artifacts/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
It now reads the version number from the csproj and publishes to nuget