### PR TITLE
Fixed workflows for .net and added workflows for aspnetcore

### DIFF
--- a/.github/workflows/nuget-publish-aspnetcore.yaml
+++ b/.github/workflows/nuget-publish-aspnetcore.yaml
@@ -1,0 +1,42 @@
+name: Publish NuGet Package - JoanComas.ScenarioUnitTesting.AspNetCore
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version-update-aspnetcore')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.x'
+
+    - name: Extract version from .csproj
+      id: extract_version
+      run: |
+        VERSION=$(grep -oPm1 "(?<=<Version>)[^<]+" JoanComas.ScenarioUnitTesting.AspNetCore/JoanComas.ScenarioUnitTesting.AspNetCore.csproj)
+        echo "Extracted version: $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build the project
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Pack the project
+      run: dotnet pack JoanComas.ScenarioUnitTesting.AspNetCore/JoanComas.ScenarioUnitTesting.AspNetCore.csproj --configuration Release --no-build -o ./artifacts /p:PackageVersion=${{ env.VERSION }}
+
+    - name: Publish to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push ./artifacts/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish-scenario-unit-testing.yml
+++ b/.github/workflows/nuget-publish-scenario-unit-testing.yml
@@ -1,4 +1,4 @@
-name: Publish NuGet Package
+name: Publish NuGet Package - JoanComas.ScenarioUnitTesting
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version-update')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version-update-net')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/set-version-aspnetcore.yml
+++ b/.github/workflows/set-version-aspnetcore.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Create new branch and PR
         run: |
-          git checkout -b version-update-aspnetcore-${{ env.VERSION }}
+          git checkout -b version-update-${{ env.VERSION }}-aspnetcore
           git add JoanComas.ScenarioUnitTesting.AspNetCore/JoanComas.ScenarioUnitTesting.AspNetCore.csproj
           git add JoanComas.ScenarioUnitTesting.AspNetCore.nuspec
           git commit -m "Update version to ${{ env.VERSION }} for AspNetCore"
-          git push origin version-update-aspnetcore-${{ env.VERSION }}
+          git push origin version-update-${{ env.VERSION }}-aspnetcore
 
       - name: Ensure label exists
         env:
@@ -46,6 +46,6 @@ jobs:
         run: |
           gh pr create --title "Update AspNetCore version to ${{ env.VERSION }}" \
                        --body "This PR updates the AspNetCore version number to ${{ env.VERSION }}." \
-                       --head version-update-aspnetcore-${{ env.VERSION }} \
+                       --head version-update-${{ env.VERSION }}-aspnetcore \
                        --base main \
                        --label version-update-aspnetcore

--- a/.github/workflows/set-version-aspnetcore.yml
+++ b/.github/workflows/set-version-aspnetcore.yml
@@ -1,0 +1,51 @@
+name: Set Version - JoanComas.ScenarioUnitTesting.AspNetCore
+
+on:
+  push:
+    tags:
+      - 'v*.*.*-aspnetcore'
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Git user
+        run: |
+          git config --global user.email "joan.comas.fdz@gmail.com"
+          git config --global user.name "Joan Comas"
+
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" | sed 's/-aspnetcore$//' >> $GITHUB_ENV
+
+      - name: Update version in .csproj and .nuspec
+        run: |
+          sed -i "s|<Version>.*</Version>|<Version>${{ env.VERSION }}</Version>|" JoanComas.ScenarioUnitTesting.AspNetCore/JoanComas.ScenarioUnitTesting.AspNetCore.csproj
+          sed -i "s|<version>.*</version>|<version>${{ env.VERSION }}</version>|" JoanComas.ScenarioUnitTesting.AspNetCore.nuspec
+
+      - name: Create new branch and PR
+        run: |
+          git checkout -b version-update-aspnetcore-${{ env.VERSION }}
+          git add JoanComas.ScenarioUnitTesting.AspNetCore/JoanComas.ScenarioUnitTesting.AspNetCore.csproj
+          git add JoanComas.ScenarioUnitTesting.AspNetCore.nuspec
+          git commit -m "Update version to ${{ env.VERSION }} for AspNetCore"
+          git push origin version-update-aspnetcore-${{ env.VERSION }}
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create version-update-aspnetcore --description "Label for AspNetCore version updates" || echo "Label already exists"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create --title "Update AspNetCore version to ${{ env.VERSION }}" \
+                       --body "This PR updates the AspNetCore version number to ${{ env.VERSION }}." \
+                       --head version-update-aspnetcore-${{ env.VERSION }} \
+                       --base main \
+                       --label version-update-aspnetcore

--- a/.github/workflows/set-version-scenario-unit-testing.yml
+++ b/.github/workflows/set-version-scenario-unit-testing.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Set up Git user
         run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
+          git config --global user.email "joan.comas.fdz@gmail.com"
+          git config --global user.name "Joan Comas"
 
       - name: Extract version from tag
         id: extract_version

--- a/.github/workflows/set-version-scenario-unit-testing.yml
+++ b/.github/workflows/set-version-scenario-unit-testing.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Create new branch and PR
         run: |
-          git checkout -b version-update-net-${{ env.VERSION }}
+          git checkout -b version-update-${{ env.VERSION }}-net
           git add JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj
           git add JoanComas.ScenarioUnitTesting.nuspec
           git commit -m "Update version to ${{ env.VERSION }} for .NET"
-          git push origin version-update-net-${{ env.VERSION }}
+          git push origin version-update-${{ env.VERSION }}-net
 
       - name: Ensure label exists
         env:
@@ -46,6 +46,6 @@ jobs:
         run: |
           gh pr create --title "Update .NET version to ${{ env.VERSION }}" \
                        --body "This PR updates the .NET version number to ${{ env.VERSION }}." \
-                       --head version-update-net-${{ env.VERSION }} \
+                       --head version-update-${{ env.VERSION }}-net \
                        --base main \
                        --label version-update-net

--- a/.github/workflows/set-version-scenario-unit-testing.yml
+++ b/.github/workflows/set-version-scenario-unit-testing.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Extract version from tag
         id: extract_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" | sed 's/-net$//' >> $GITHUB_ENV
 
       - name: Update version in .csproj and .nuspec
         run: |
@@ -28,11 +28,11 @@ jobs:
 
       - name: Create new branch and PR
         run: |
-          git checkout -b version-update-${{ env.VERSION }}
+          git checkout -b version-update-net-${{ env.VERSION }}
           git add JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj
           git add JoanComas.ScenarioUnitTesting.nuspec
-          git commit -m "Update version to ${{ env.VERSION }}"
-          git push origin version-update-${{ env.VERSION }}
+          git commit -m "Update version to ${{ env.VERSION }} for .NET"
+          git push origin version-update-net-${{ env.VERSION }}
 
       - name: Ensure label exists
         env:
@@ -44,8 +44,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create --title "Update version to ${{ env.VERSION }}" \
-                       --body "This PR updates the version number to ${{ env.VERSION }}." \
-                       --head version-update-${{ env.VERSION }} \
+          gh pr create --title "Update .NET version to ${{ env.VERSION }}" \
+                       --body "This PR updates the .NET version number to ${{ env.VERSION }}." \
+                       --head version-update-net-${{ env.VERSION }} \
                        --base main \
                        --label version-update-net

--- a/.github/workflows/set-version-scenario-unit-testing.yml
+++ b/.github/workflows/set-version-scenario-unit-testing.yml
@@ -1,9 +1,9 @@
-name: Set Version
+name: Set Version - JoanComas.ScenarioUnitTesting
 
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*-net'
 
 jobs:
   update-version:
@@ -21,12 +21,12 @@ jobs:
         id: extract_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
-      - name: Update version in .csproj file
+      - name: Update version in .csproj and .nuspec
         run: |
           sed -i "s|<Version>.*</Version>|<Version>${{ env.VERSION }}</Version>|" JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj
           sed -i "s|<version>.*</version>|<version>${{ env.VERSION }}</version>|" JoanComas.ScenarioUnitTesting.nuspec
 
-      - name: Create new branch
+      - name: Create new branch and PR
         run: |
           git checkout -b version-update-${{ env.VERSION }}
           git add JoanComas.ScenarioUnitTesting/JoanComas.ScenarioUnitTesting.csproj
@@ -34,11 +34,11 @@ jobs:
           git commit -m "Update version to ${{ env.VERSION }}"
           git push origin version-update-${{ env.VERSION }}
 
-      - name: Create version-update label if not exists
+      - name: Ensure label exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh label create version-update --description "Label for version updates" || echo "Label already exists"
+          gh label create version-update-net --description "Label for .NET version updates" || echo "Label already exists"
 
       - name: Create Pull Request
         env:
@@ -48,4 +48,4 @@ jobs:
                        --body "This PR updates the version number to ${{ env.VERSION }}." \
                        --head version-update-${{ env.VERSION }} \
                        --base main \
-                       --label version-update
+                       --label version-update-net


### PR DESCRIPTION
They are basically duplicated, but target different csproj and nuspec files.

Setting a tag with the proper suffix triggers the set-version workflows.

After this pr is merged, i am going to test publishing in nuget, by tagging then merging the automatic PR that the set-version workflow generates.